### PR TITLE
Use tempdir for temporary .o files

### DIFF
--- a/examples/package-lock.json
+++ b/examples/package-lock.json
@@ -22,7 +22,7 @@
       "hasInstallScript": true,
       "license": "UPL-1.0",
       "dependencies": {
-        "roc-lang": "0.0.3-2023-10-19-nightly"
+        "roc-lang": "0.0.3-2023-11-27-nightly"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
@@ -6861,7 +6861,7 @@
         "eslint-plugin-prettier": "4.2.1",
         "eslint-plugin-promise": "6.0.1",
         "eslint-plugin-tsdoc": "0.2.17",
-        "roc-lang": "0.0.3-2023-10-19-nightly",
+        "roc-lang": "0.0.3-2023-11-27-nightly",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.3"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "UPL-1.0",
       "dependencies": {
-        "roc-lang": "0.0.3-2023-10-19-nightly"
+        "roc-lang": "0.0.3-2023-11-27-nightly"
       },
       "devDependencies": {
         "@ava/typescript": "^4.0.0",
@@ -279,9 +279,9 @@
       }
     },
     "node_modules/@roc-installer-assets/darwin_arm64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_arm64/-/darwin_arm64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-6SwFEcQ5WMxHJ3jl37X+XRxkJNi9vGVM/EWYNneiMdbjDzIrrOTTorNfxnE/B0QfL93oTdrdylTxIjiLV50U5w==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_arm64/-/darwin_arm64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-dDB9nSvT6QxkiGrlTDM987euefWruYfXUj6boSJoj0SyBKuKK09nXytZVTzcvDHWLrsfwt3UA15TkrM8e7cLHQ==",
       "cpu": [
         "arm64"
       ],
@@ -291,9 +291,9 @@
       ]
     },
     "node_modules/@roc-installer-assets/darwin_x64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_x64/-/darwin_x64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-cL9rewPtyYVoA6tbUcNb+Xh3S7FpyEWdGfyyQiiOtxFAvxgzWoKYwyN3cMiDr/dNL/J5yaXJMCLxB7c19b4ZUQ==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_x64/-/darwin_x64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-DCQzYP5CsfQ0MTLqSDYmygldupHia1Q3b2/qpm9PA4BJRIJbzpa3bq8p1KEUR/0/YsM0Q8dbc0F3EDhvD+8NvQ==",
       "cpu": [
         "x64"
       ],
@@ -303,9 +303,9 @@
       ]
     },
     "node_modules/@roc-installer-assets/linux_arm64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_arm64/-/linux_arm64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-3KhfeNSoAUjEpnyhtqEsbaBvodKBc5u4yAWkX7Y6vD3qKn87epUjOZTkBz1jwvj5D5fBgJq2axKAc65dIkxtHw==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_arm64/-/linux_arm64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-LF0nOJf7s2dACijTSnuBDCuLVgjWGd3ebv8KRCtIu1g8LyncQ/WC2ro1+q3MIxp/CwelAQier1W0vHUnGYFNJg==",
       "cpu": [
         "arm64"
       ],
@@ -315,9 +315,9 @@
       ]
     },
     "node_modules/@roc-installer-assets/linux_x64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_x64/-/linux_x64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-H69LfPyXwKyowqsbFXUSKCCtE6/7sUNO8K0/ZqYrtgdvh48OCsEt2rcaqL6xXrDAbYWQTzZoLQ87nHTh2twdwg==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_x64/-/linux_x64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-YPp+fp3kNl2PKpSL0zaZMkZaUG3A9I6oAWzhxykaz5g/noFUHJ4Ndz2ewtf5Qyy8vpDGapXSL2oMbyOPK70kgA==",
       "cpu": [
         "x64"
       ],
@@ -4635,18 +4635,18 @@
       }
     },
     "node_modules/roc-lang": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/roc-lang/-/roc-lang-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-RBz/QupKh1291vhve6IrG1ZyLUtGU2103GXJZGZ9uzRTzJpm/G5vvN8qqfwYe5YXDQFpm7q9XJIE4Jrhp5l4WQ==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/roc-lang/-/roc-lang-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-HzZioI6OD+QzDIm5MMrKvlVyiHlajamCB3bRtbg2tbE1FrBbTeS2Rp+AySTWRyEW23/xXN0SLO2oWg5HG6Ynxw==",
       "hasInstallScript": true,
       "bin": {
         "roc": "bin/roc"
       },
       "optionalDependencies": {
-        "@roc-installer-assets/darwin_arm64": "0.0.3-2023-10-19-nightly",
-        "@roc-installer-assets/darwin_x64": "0.0.3-2023-10-19-nightly",
-        "@roc-installer-assets/linux_arm64": "0.0.3-2023-10-19-nightly",
-        "@roc-installer-assets/linux_x64": "0.0.3-2023-10-19-nightly"
+        "@roc-installer-assets/darwin_arm64": "0.0.3-2023-11-27-nightly",
+        "@roc-installer-assets/darwin_x64": "0.0.3-2023-11-27-nightly",
+        "@roc-installer-assets/linux_arm64": "0.0.3-2023-11-27-nightly",
+        "@roc-installer-assets/linux_x64": "0.0.3-2023-11-27-nightly"
       }
     },
     "node_modules/run-applescript": {
@@ -5914,27 +5914,27 @@
       }
     },
     "@roc-installer-assets/darwin_arm64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_arm64/-/darwin_arm64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-6SwFEcQ5WMxHJ3jl37X+XRxkJNi9vGVM/EWYNneiMdbjDzIrrOTTorNfxnE/B0QfL93oTdrdylTxIjiLV50U5w==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_arm64/-/darwin_arm64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-dDB9nSvT6QxkiGrlTDM987euefWruYfXUj6boSJoj0SyBKuKK09nXytZVTzcvDHWLrsfwt3UA15TkrM8e7cLHQ==",
       "optional": true
     },
     "@roc-installer-assets/darwin_x64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_x64/-/darwin_x64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-cL9rewPtyYVoA6tbUcNb+Xh3S7FpyEWdGfyyQiiOtxFAvxgzWoKYwyN3cMiDr/dNL/J5yaXJMCLxB7c19b4ZUQ==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/darwin_x64/-/darwin_x64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-DCQzYP5CsfQ0MTLqSDYmygldupHia1Q3b2/qpm9PA4BJRIJbzpa3bq8p1KEUR/0/YsM0Q8dbc0F3EDhvD+8NvQ==",
       "optional": true
     },
     "@roc-installer-assets/linux_arm64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_arm64/-/linux_arm64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-3KhfeNSoAUjEpnyhtqEsbaBvodKBc5u4yAWkX7Y6vD3qKn87epUjOZTkBz1jwvj5D5fBgJq2axKAc65dIkxtHw==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_arm64/-/linux_arm64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-LF0nOJf7s2dACijTSnuBDCuLVgjWGd3ebv8KRCtIu1g8LyncQ/WC2ro1+q3MIxp/CwelAQier1W0vHUnGYFNJg==",
       "optional": true
     },
     "@roc-installer-assets/linux_x64": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_x64/-/linux_x64-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-H69LfPyXwKyowqsbFXUSKCCtE6/7sUNO8K0/ZqYrtgdvh48OCsEt2rcaqL6xXrDAbYWQTzZoLQ87nHTh2twdwg==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/@roc-installer-assets/linux_x64/-/linux_x64-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-YPp+fp3kNl2PKpSL0zaZMkZaUG3A9I6oAWzhxykaz5g/noFUHJ4Ndz2ewtf5Qyy8vpDGapXSL2oMbyOPK70kgA==",
       "optional": true
     },
     "@tsconfig/node10": {
@@ -8850,14 +8850,14 @@
       }
     },
     "roc-lang": {
-      "version": "0.0.3-2023-10-19-nightly",
-      "resolved": "https://registry.npmjs.org/roc-lang/-/roc-lang-0.0.3-2023-10-19-nightly.tgz",
-      "integrity": "sha512-RBz/QupKh1291vhve6IrG1ZyLUtGU2103GXJZGZ9uzRTzJpm/G5vvN8qqfwYe5YXDQFpm7q9XJIE4Jrhp5l4WQ==",
+      "version": "0.0.3-2023-11-27-nightly",
+      "resolved": "https://registry.npmjs.org/roc-lang/-/roc-lang-0.0.3-2023-11-27-nightly.tgz",
+      "integrity": "sha512-HzZioI6OD+QzDIm5MMrKvlVyiHlajamCB3bRtbg2tbE1FrBbTeS2Rp+AySTWRyEW23/xXN0SLO2oWg5HG6Ynxw==",
       "requires": {
-        "@roc-installer-assets/darwin_arm64": "0.0.3-2023-10-19-nightly",
-        "@roc-installer-assets/darwin_x64": "0.0.3-2023-10-19-nightly",
-        "@roc-installer-assets/linux_arm64": "0.0.3-2023-10-19-nightly",
-        "@roc-installer-assets/linux_x64": "0.0.3-2023-10-19-nightly"
+        "@roc-installer-assets/darwin_arm64": "0.0.3-2023-11-27-nightly",
+        "@roc-installer-assets/darwin_x64": "0.0.3-2023-11-27-nightly",
+        "@roc-installer-assets/linux_arm64": "0.0.3-2023-11-27-nightly",
+        "@roc-installer-assets/linux_x64": "0.0.3-2023-11-27-nightly"
       }
     },
     "run-applescript": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "scripts": {
     "check": "node clang-tidy.js && clang-format -n src/*.c && tsc --noEmit",
     "format": "clang-format -i src/*.c",
-    "build": "esbuild --bundle src/index.ts --outfile=dist/index.js --platform=node --target=node16.16.0 --sourcemap && tsc --declaration --emitDeclarationOnly --outDir dist && cp src/*.roc dist/ && cp src/*.c dist/",
+    "build": "esbuild --bundle src/index.ts --outfile=dist/index.js --platform=node --target=node16.16.0 --sourcemap && tsc --declaration --emitDeclarationOnly --outDir dist && cp src/*.roc dist/ && cp src/*.d.ts dist/ && cp src/*.c dist/",
     "dev": "ts-node src/index.ts",
     "test": "./test.sh",
     "prepublishOnly": "npm run build",
@@ -21,7 +21,7 @@
   "author": "Richard Feldman",
   "license": "UPL-1.0",
   "dependencies": {
-    "roc-lang": "0.0.3-2023-10-19-nightly"
+    "roc-lang": "0.0.3-2023-11-27-nightly"
   },
   "peerDependencies": {
     "esbuild": "^0.14.39"

--- a/src/build-roc.ts
+++ b/src/build-roc.ts
@@ -198,7 +198,7 @@ export function callRoc<T extends JsonValue, U extends JsonValue>(input: T): U
   const ccTarget = target === "" ? "" : `--target=${ccTargetFromRocTarget(target)}`
   const rocLibDir = rocFileDir
 
-  const rocLib = path.join(rocLibDir, rocFileName.replace(/\.roc$/, ".o"))
+  const rocLib = path.join(rocLibDir, rocFileName.replace(/\.roc$/, `-${target}.o`))
   const cGluePath = path.join(__dirname, "node-to-roc.c")
   const includeRoot = path.resolve(process.execPath, "..", "..")
   const includes = [

--- a/src/build-roc.ts
+++ b/src/build-roc.ts
@@ -250,10 +250,7 @@ export function callRoc<T extends JsonValue, U extends JsonValue>(input: T): U
 
   const libraries = ["c", "m", "pthread", "dl", "util"].map((library) => "-l" + library)
 
-  if (buildingForMac) {
-    // macOS always requires -lSystem
-    libraries.push("-lSystem")
-  } else if (buildingForLinux) {
+  if (buildingForLinux) {
     // Linux requires -lrt
     libraries.push("-lrt")
   }

--- a/src/build-roc.ts
+++ b/src/build-roc.ts
@@ -112,6 +112,8 @@ const buildRocFile = (
   const errors = []
   const buildingForMac = target.startsWith("macos") || (target === "" && os.platform() === "darwin")
   const buildingForLinux = target.startsWith("linux") || (target === "" && os.platform() === "linux")
+  const rocBuildOutputDir = os.tmpdir()
+  const rocBuildOutputFile = path.join(rocBuildOutputDir, rocFileName.replace(/\.roc$/, ".o"))
 
   // Build the initial Roc object binary for the current OS/architecture.
   //
@@ -125,6 +127,8 @@ const buildRocFile = (
       target === "" ? "" : `--target=${target}`,
       optimize ? "--optimize" : "",
       "--no-link",
+      "--output",
+      rocBuildOutputFile,
       rocFilePath
     ].filter((part) => part !== ""),
   )
@@ -196,9 +200,6 @@ export function callRoc<T extends JsonValue, U extends JsonValue>(input: T): U
 
   // For now, these are hardcoded. In the future we can extract them into a function to call for multiple entrypoints.
   const ccTarget = target === "" ? "" : `--target=${ccTargetFromRocTarget(target)}`
-  const rocLibDir = rocFileDir
-
-  const rocLib = path.join(rocLibDir, rocFileName.replace(/\.roc$/, `-${target}.o`))
   const cGluePath = path.join(__dirname, "node-to-roc.c")
   const includeRoot = path.resolve(process.execPath, "..", "..")
   const includes = [
@@ -262,7 +263,7 @@ export function callRoc<T extends JsonValue, U extends JsonValue>(input: T): U
       ccTarget === "" ? "" : ccTarget,
       "-o",
       addonPath,
-      rocLib,
+      rocBuildOutputFile,
       cGluePath,
       defines,
       includes,


### PR DESCRIPTION
Also fixes the `-lSystem` warning, upgrades `roc-lang` to the latest version,  and fixes the `.d.ts` generation to use `main.roc.d.ts` instead of `main.d.ts`