### PR TITLE
Fix parallel builds

### DIFF
--- a/src/build-roc.ts
+++ b/src/build-roc.ts
@@ -266,8 +266,6 @@ const buildRocFile = (
     .filter((part) => part !== "")
     .join(" ")
 
-    console.log("exec:", cmd)
-
   // Compile the node <-> roc C bridge and statically link in the .o binary (produced by `roc`)
   // into the .node addon binary
   execSync(cmd, { stdio: "inherit" })

--- a/src/build-roc.ts
+++ b/src/build-roc.ts
@@ -115,8 +115,10 @@ const buildRocFile = (
   const errors = []
   const buildingForMac = target.startsWith("macos") || (target === "" && os.platform() === "darwin")
   const buildingForLinux = target.startsWith("linux") || (target === "" && os.platform() === "linux")
-  const rocBuildOutputDir = os.tmpdir()
-  const rocBuildOutputFile = path.join(rocBuildOutputDir, rocFileName.replace(/\.roc$/, ".o"))
+  const tmpDir = os.tmpdir()
+  const rocBuildOutputDir = fs.mkdtempSync(`${tmpDir}${path.sep}`)
+  const targetSuffix = (target === "" ? "native" : target)
+  const rocBuildOutputFile = path.join(rocBuildOutputDir, rocFileName.replace(/\.roc$/, `-${targetSuffix}.o`))
 
   // Build the initial Roc object binary for the current OS/architecture.
   //


### PR DESCRIPTION
This does two things to make things safer for parallel builds:
- Append the target string onto the intermediary `main.o`
- Generate a random directory inside the OS tempdir with `mkdtemp`, so parallel builds won't even use the same directory